### PR TITLE
fix: "Copy as rich text" triggers "Send via Gmail"

### DIFF
--- a/content/isolated/rich-copy.js
+++ b/content/isolated/rich-copy.js
@@ -11,13 +11,15 @@
 
 	const CHECK_SVG = `<svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style="flex-shrink: 0;"><path d="M15.3 5.3a1 1 0 0 1 1.4 1.4l-8 8a1 1 0 0 1-1.4 0l-4-4a1 1 0 0 1 1.4-1.4L8 12.58l7.3-7.3z"/></svg>`;
 
+	const MESSAGE_ACTIONS_SELECTOR = '[role="toolbar"][aria-label="Message actions"], [role="group"][aria-label="Message actions"], [data-cds="MessageActions"]';
+
 	function findContentBlockCopyButtons() {
 		const results = [];
 		const copyButtons = document.querySelectorAll('button[aria-label="Copy message"]');
 
 		for (const btn of copyButtons) {
 			if (btn.dataset.testid === 'action-bar-copy') continue;
-			if (btn.closest('[role="toolbar"][aria-label="Message actions"], [role="group"][aria-label="Message actions"]')) continue;
+			if (btn.closest(MESSAGE_ACTIONS_SELECTOR)) continue;
 			if (btn.nextElementSibling?.classList.contains(RICH_COPY_CLASS)) continue;
 
 			results.push(btn);
@@ -26,19 +28,39 @@
 		return results;
 	}
 
+	// Copy buttons in artifact/file action rows carry no aria-label or testid, just an
+	// icon-font glyph and a "Copy" label. Never assume a split dropdown's primary button
+	// is the copy one — that slot also holds actions like "Send via Gmail".
+	const COPY_ICON_GLYPH = '\ue056';
+
+	function isNativeCopyButton(btn) {
+		if (btn.classList.contains(RICH_COPY_CLASS)) return false;
+		if (btn.dataset.testid === 'action-bar-copy') return false;
+		// The message action bar has its own copy button, handled above.
+		if (btn.closest(MESSAGE_ACTIONS_SELECTOR)) return false;
+
+		const label = (btn.getAttribute('aria-label') || '').trim().toLowerCase();
+		if (label && label !== 'copy') return false;
+
+		const icon = btn.querySelector('[data-cds="Icon"]');
+		if (icon && icon.textContent === COPY_ICON_GLYPH) return true;
+
+		return (btn.textContent || '').trim().toLowerCase() === 'copy';
+	}
+
 	function findArtifactCopyButtons() {
 		const results = [];
-		const splitDropdowns = document.querySelectorAll('[data-cds="SplitDropdownButton"]');
 
-		for (const dropdown of splitDropdowns) {
-			const copyBtn = dropdown.querySelector('.contents > button');
-			if (!copyBtn) continue;
+		for (const copyBtn of document.querySelectorAll('button[data-cds="Button"]')) {
+			if (!isNativeCopyButton(copyBtn)) continue;
 
-			const parent = dropdown.parentElement;
+			// Sit next to the whole split dropdown when the copy button lives inside one.
+			const anchor = copyBtn.closest('[data-cds="SplitDropdownButton"]') || copyBtn;
+			const parent = anchor.parentElement;
 			if (!parent) continue;
 			if (parent.querySelector('.' + RICH_COPY_CLASS)) continue;
 
-			results.push({ copyBtn, dropdown });
+			results.push({ copyBtn, anchor });
 		}
 
 		return results;
@@ -117,34 +139,23 @@
 		return btn;
 	}
 
-	function createArtifactRichCopyButton(copyBtn, dropdown) {
-		const parent = dropdown.parentElement;
-		const siblingBtn = parent.querySelector(':scope > button[data-cds="Button"]');
+	function createArtifactRichCopyButton(copyBtn) {
+		const btn = copyBtn.cloneNode(true);
+		btn.className = copyBtn.className + ' ' + RICH_COPY_CLASS;
 
-		let btn;
-		if (siblingBtn) {
-			btn = siblingBtn.cloneNode(false);
-			btn.className = siblingBtn.className + ' ' + RICH_COPY_CLASS;
-
-			const iconSpans = siblingBtn.querySelectorAll(':scope > span');
-			for (const span of iconSpans) {
-				const clone = span.cloneNode(true);
-				if (clone.getAttribute('aria-hidden') !== 'true' || clone.querySelector('[data-cds="Icon"]')) {
-					const iconEl = clone.querySelector('[data-cds="Icon"]');
-					if (iconEl) {
-						iconEl.innerHTML = RICH_COPY_SVG;
-					} else if (!clone.classList.contains('absolute')) {
-						clone.innerHTML = RICH_COPY_SVG;
-					}
-				}
-				btn.appendChild(clone);
-			}
+		const iconEl = btn.querySelector('[data-cds="Icon"]');
+		if (iconEl) {
+			iconEl.innerHTML = RICH_COPY_SVG;
+		} else {
+			btn.innerHTML = RICH_COPY_SVG;
 		}
 
-		if (!btn) {
-			btn = document.createElement('button');
-			btn.className = RICH_COPY_CLASS;
-			btn.innerHTML = RICH_COPY_SVG;
+		// Relabel so it doesn't read as a second "Copy" right next to the native one.
+		const labelNode = [...btn.querySelectorAll('span')]
+			.flatMap((span) => [...span.childNodes])
+			.find((node) => node.nodeType === Node.TEXT_NODE && node.nodeValue.trim());
+		if (labelNode) {
+			labelNode.nodeValue = 'Copy rich text';
 		}
 
 		btn.setAttribute('aria-label', 'Copy as rich text');
@@ -170,9 +181,9 @@
 		}
 
 		const artifactTargets = findArtifactCopyButtons();
-		for (const { copyBtn, dropdown } of artifactTargets) {
-			const richBtn = createArtifactRichCopyButton(copyBtn, dropdown);
-			dropdown.insertAdjacentElement('afterend', richBtn);
+		for (const { copyBtn, anchor } of artifactTargets) {
+			const richBtn = createArtifactRichCopyButton(copyBtn);
+			anchor.insertAdjacentElement('afterend', richBtn);
 		}
 	}
 


### PR DESCRIPTION
## Problem

Clicking **Copy as rich text** on an artifact/file block now opens a Gmail compose window instead of copying.

`findArtifactCopyButtons()` assumed the primary button inside `[data-cds="SplitDropdownButton"]` was the copy button:

```js
const copyBtn = dropdown.querySelector('.contents > button');
```

claude.ai has since repurposed that split dropdown for **Send via Gmail** and moved Copy out to a plain sibling button. On a current chat every `SplitDropdownButton`'s `.contents > button` reports `"Send via Gmail"`, so the rich-copy button was clicking that.

## Fix

- New `isNativeCopyButton()` identifies the real copy button by its CDS icon glyph (`U+E056`) or a `"Copy"` accessible name, and rejects anything with a different `aria-label` (`Send via Gmail`, `More options`), the message action bar's own copy button, and our injected clone.
- `findArtifactCopyButtons()` scans `button[data-cds="Button"]` directly rather than anchoring on the dropdown. The rich button is still inserted after the whole split dropdown when the copy button happens to live inside one, so both layouts work.
- `createArtifactRichCopyButton()` deep-clones the copy button. The old shallow-clone-plus-span-rebuild existed only because it was cloning a *different* button than the one it wired up.
- The injected button is relabelled **Copy rich text** — otherwise the row shows two adjacent buttons both reading "Copy".

## Verification

On a live chat with three email-draft blocks:

- detection matched the 3 real Copy buttons; rejected all 3 "Send via Gmail" buttons, both "More options" buttons, the `user-message-copy` action-bar button, and the previously-injected rich-copy buttons
- the action row renders `Copy | Copy rich text | Send via Gmail ▾`
- driving the full handshake produced correct markup on the clipboard path — `<p>Subject: RE: UPS Peak Season</p>…<ol><li>…` — with both `text/html` and `text/plain` in the `ClipboardItem`

No version bump, since those land as separate commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)